### PR TITLE
Pck signature padding fix

### DIFF
--- a/DALTools/DALLib/IO/ExtendedBinary.cs
+++ b/DALTools/DALLib/IO/ExtendedBinary.cs
@@ -330,7 +330,7 @@ namespace DALLib.IO
                 {
                     if (expected.Length + padding >= 0x14)
                         JumpBehind((expected.Length + padding) - 0x14 + 1);
-                    if (expected.Length + padding >= 0x0C)
+                    else if (expected.Length + padding >= 0x0C)
                         JumpBehind((expected.Length + padding) - 0x0C + 1);
                     else if (expected.Length + padding >= 0x08)
                         JumpBehind((expected.Length + padding) - 0x08 + 1);
@@ -356,7 +356,7 @@ namespace DALLib.IO
                 {
                     if (expected.Length + padding >= 0x14)
                         JumpBehind((expected.Length + padding) - 0x14 + 1);
-                    if (expected.Length + padding >= 0x0C)
+                    else if (expected.Length + padding >= 0x0C)
                         JumpBehind((expected.Length + padding) - 0x0C + 1);
                     else if (expected.Length + padding >= 0x08)
                         JumpBehind((expected.Length + padding) - 0x08 + 1);


### PR DESCRIPTION
Signature read code is missing `else`, causing error when sig + padding length >= 0x14